### PR TITLE
Update s3fs to version 2021.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.7.0" %}
+{% set version = "2021.8.1" %}
 
 package:
   name: s3fs
@@ -7,7 +7,7 @@ package:
 source:
   fn: s3fs-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/s3fs/s3fs-{{ version }}.tar.gz
-  sha256: 293294ec8ed08605617db440e3a50229a413dc16dcf32c948fae8cbd9b02ae96
+  sha256: 5eac19361889e743bf2ea702c7cd0d82c09ea0f46af12872febce892b2139e7f
 
 build:
   number: 0


### PR DESCRIPTION
1. check the upstream
2. check the pinnings
https://github.com/dask/s3fs/blob/2021.08.1/setup.py
https://github.com/dask/s3fs/blob/2021.08.1/setup.cfg

The aiobotocore pinings are not specified 

3. verify the changelogs
https://github.com/dask/s3fs/blob/2021.08.1/docs/source/changelog.rst

there were no breaking changes mentioned on the change log. 
The only changes mentioned where bug fixes or added features

2021.08.1
retry on IncompleteRead (#525)
fix isdir for missing bucket (#522)
raise for glob("*") (#5167)

2021.08.0
fix for aiobotocore update (#510)

2021.07.0
make bucket in put(recursive) (#496)
non-truthy prefixes (#497)
implement rm_file (#499)


4. additional research
There is one open issue that requires some attention
https://github.com/dask/s3fs/issues/528
The issue seems to be related to having the correct pin on the aiobotocore version. 
The issues seems to be corrected in the upstream
https://github.com/dask/s3fs/issues/529
5. verify dev_url
6. verify doc_url
7. verify that pip is checked
8. verify that wheel is available
9. verify the test section
10. additional tests

      In order to test the application the following command was used:
      `conda-build s3fs-feedstock --test`
      The test result was the following:
      `All tests passed`

based on the test results and on the research we can conclude that it is safe to update `s3fs` to version 2021.8.1