### PR TITLE
s3fs 2022.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - aiohttp >=3.7.1,<4
     - fsspec {{ version }}
 
-
 test:
   imports:
     - s3fs
@@ -38,7 +37,7 @@ test:
     - pip check
 
 about:
-  home: http://s3fs.readthedocs.io/en/latest/
+  home: https://s3fs.readthedocs.io/en/latest/
   license: BSD-3-Clause
   license_family: BSD
   summary: Convenient Filesystem interface over S3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.8.1" %}
+{% set version = "2022.1.0" %}
 
 package:
   name: s3fs
@@ -7,7 +7,7 @@ package:
 source:
   fn: s3fs-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/s3fs/s3fs-{{ version }}.tar.gz
-  sha256: 5eac19361889e743bf2ea702c7cd0d82c09ea0f46af12872febce892b2139e7f
+  sha256: 6bafc1f6b4e935ea59512c0f38d5cb9c299dbbfe738e40c3d1de8f67b4ee1fd4
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,20 +10,21 @@ source:
   sha256: 6bafc1f6b4e935ea59512c0f38d5cb9c299dbbfe738e40c3d1de8f67b4ee1fd4
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
     - pip
     - wheel
 
   run:
     - python >=3.6
-    - aiobotocore >=1.0.1
+    - aiobotocore ==2.1.0
+    - aiohttp >=3.7.1,<4
     - fsspec {{ version }}
 
 
@@ -32,6 +33,7 @@ test:
     - s3fs
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Update s3fs to 2022.1.0

Changelog: https://github.com/fsspec/s3fs/blob/2022.01.0/docs/source/changelog.rst
License: https://github.com/fsspec/s3fs/blob/2022.01.0/LICENSE.txt
Upstream setup file: https://github.com/fsspec/s3fs/blob/2022.01.0/setup.py
Upstream requirements: https://github.com/fsspec/s3fs/blob/2022.01.0/requirements.txt

Actions:
1. Reset build number to 0
2. Fix `python` in `host`
3. Update run dependencies: `aiobotocore >=2.1.0`, add `aiohttp >=3.7.1,<4`
4. Add `python <3.10` in test/requires