### PR TITLE
2022.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
   run:
     - python
-    - aiobotocore >=2.4.0,==2.4.*
+    - aiobotocore 2.4.*
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - fsspec {{ version }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
   summary: Convenient Filesystem interface over S3
   license_file: LICENSE.txt
   dev_url: https://github.com/dask/s3fs
-  doc_url: https://s3fs.readthedocs.io/en/latest/
+  doc_url: https://s3fs.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,6 @@ extra:
     - mrocklin
     - koverholt
     - tomaugspurger
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,8 @@ about:
   license_family: BSD
   summary: Convenient Filesystem interface over S3
   license_file: LICENSE.txt
-  license_url: https://github.com/fsspec/s3fs/blob/{{ version }}/LICENSE.txt
   dev_url: https://github.com/dask/s3fs
   doc_url: https://s3fs.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/fsspec/s3fs/tree/{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2022.10.0" %}
+{% set version = "2022.11.0" %}
 
 package:
   name: s3fs
@@ -7,7 +7,7 @@ package:
 source:
   fn: s3fs-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/s3fs/s3fs-{{ version }}.tar.gz
-  sha256: e8deb80f20bd0b2059141b874fdb9d6aeb8cce35312ea5f2c02b225a78a00406
+  sha256: 10c5ac283a4f5b67ffad6d1f25ff7ee026142750c5c5dc868746cd904f617c33
 
 build:
   skip: True #[py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
   run:
     - python
-    - aiobotocore ~=2.4.0
+    - aiobotocore >=2.4.0,==2.4.*
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - fsspec {{ version }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 10c5ac283a4f5b67ffad6d1f25ff7ee026142750c5c5dc868746cd904f617c33
 
 build:
-  skip: True #[py<37]
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
   run:
     - python
-    - aiobotocore ==2.4.0
+    - aiobotocore ~=2.4.0
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - fsspec {{ version }}
 


### PR DESCRIPTION
# s3fs 2022.11.0

upstream: https://github.com/fsspec/s3fs/tree/2022.11.0
jira: https://anaconda.atlassian.net/browse/PKG-805
`setup.py`: https://github.com/fsspec/s3fs/blob/2022.11.0/setup.py
`requirements.txt`: https://github.com/fsspec/s3fs/blob/2022.11.0/requirements.txt
changelog: https://github.com/fsspec/s3fs/compare/2022.10.0...2022.11.0

## Changes
- Update version and SHA
- Minor whitespace and about section updates
- Adjust `aiobotocore` pinning to match upstream
