### PR TITLE
PKG-6740: Update s3fs 2022.11.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-
 channels:
   - https://staging.continuum.io/prefect/fs/filesystem-spec-feedstock/pr19/2466809

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/filesystem-spec-feedstock/pr19/2466809

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/filesystem-spec-feedstock/pr19/2466809

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # aiobotocore 2.4.* is not avaliable for py>311
+  skip: True  # [py<37 or py>311]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
+{% set name = "s3fs" %}
 {% set version = "2022.11.0" %}
 
 package:
-  name: s3fs
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: s3fs-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/s/s3fs/s3fs-{{ version }}.tar.gz
-  sha256: 10c5ac283a4f5b67ffad6d1f25ff7ee026142750c5c5dc868746cd904f617c33
+  url: https://github.com/fsspec/s3fs/archive/refs/tags/2022.11.0.tar.gz
+  sha256: 8957b7e1acadf00e9201da6386d55593ce6478a3b392a1d06c3758bbf78ece5d
 
 build:
-  skip: True  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -20,20 +20,33 @@ requirements:
     - setuptools
     - pip
     - wheel
-
   run:
     - python
     - aiobotocore 2.4.*
+    - fsspec =={{ version }}
     - aiohttp !=4.0.0a0,!=4.0.0a1
-    - fsspec {{ version }}
+
+# This tests failed when trying to create the bucket in the S3 mock moto_server
+# botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://127.0.0.1:5555/test"
+{% set ignore_tests = " --ignore=s3fs/tests/test_mapping.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=s3fs/tests/test_s3fs.py" %}
 
 test:
+  source_files:
+    - s3fs
+    - pytest.ini
   imports:
     - s3fs
-  requires:
-    - pip
   commands:
     - pip check
+    - pytest -v {{ ignore_tests }}
+  requires:
+    - pip
+    - pytest >=4.2.0
+    - urllib3
+    - requests
+    - moto >=4
+    - flask
 
 about:
   description : |
@@ -52,6 +65,3 @@ extra:
     - mrocklin
     - koverholt
     - tomaugspurger
-  skip-lints:
-    - missing_doc_source_url
-    - missing_license_url


### PR DESCRIPTION
s3fs 2022.11.0 

**Destination channel:** defaults

- [PKG-6740](https://anaconda.atlassian.net/browse/PKG-6740) 
- [source code](https://github.com/fsspec/s3fs/tree/2022.11.0)
- [PyPi](https://pypi.org/project/s3fs/2022.11.0/)
- [conda-forge](https://github.com/conda-forge/s3fs-feedstock)

[PKG-6740]: https://anaconda.atlassian.net/browse/PKG-6740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ