### PR TITLE
s3fs 2026.2.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/filesystem-spec-feedstock/pr27/55c72ca

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/filesystem-spec-feedstock/pr27/55c72ca

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "s3fs" %}
-{% set version = "2026.1.0" %}
+{% set version = "2026.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b7a352dfb9553a2263b7ea4575d90cd3c64eb76cfc083b99cb90b36b31e9d09d
+  sha256: 91cb2a9f76e35643b76eeac3f47a6165172bb3def671f76b9111c8dd5779a2ac
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - aiobotocore >=2.5.4,<4.0.0
+    - aiobotocore >=2.19.0,<4.0.0
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - fsspec =={{ version }}
 


### PR DESCRIPTION
s3fs 2026.2.0 

**Destination channel:** Defaults

### Links

- [PKG-12990]
- dev_url:        https://github.com/fsspec/s3fs/tree/2026.2.0
- conda_forge:    https://github.com/conda-forge/s3fs-feedstock
- pypi:           https://pypi.org/project/s3fs/2026.2.0
- pypi inspector: https://inspector.pypi.io/project/s3fs/2026.2.0

### Explanation of changes:

- new version number


[PKG-12990]: https://anaconda.atlassian.net/browse/PKG-12990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ