### PR TITLE
s3fs 2026.4.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "s3fs" %}
-{% set version = "2026.2.0" %}
+{% set version = "2026.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 91cb2a9f76e35643b76eeac3f47a6165172bb3def671f76b9111c8dd5779a2ac
+  sha256: 5bdce0abb00b0435ee150807a45fea727451dbc22de4cbc116464f8504ab9d37
 
 build:
   number: 0
-  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<310]
 
 requirements:
   host:


### PR DESCRIPTION
s3fs 2026.4.0 

**Destination channel:** Defaults

### Links

- [PKG-15063]
- dev_url:        https://github.com/fsspec/s3fs/tree/2026.4.0
- conda_forge:    https://github.com/conda-forge/s3fs-feedstock
- pypi:           https://pypi.org/project/s3fs/2026.4.0
- pypi inspector: https://inspector.pypi.io/project/s3fs/2026.4.0

### Explanation of changes:

- new version number


[PKG-15063]: https://anaconda.atlassian.net/browse/PKG-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ